### PR TITLE
Fix debug log formatting

### DIFF
--- a/server.py
+++ b/server.py
@@ -71,7 +71,7 @@ class ColorizedFormatter(logging.Formatter):
     BOLD = "\033[1m"
 
     def format(self, record):
-        if record.levelno == logging.debug and "MODEL MAPPING" in record.msg:
+        if record.levelno == logging.DEBUG and isinstance(record.msg, str) and "MODEL MAPPING" in record.msg:
             # Apply colors and formatting to model mapping logs
             return f"{self.BOLD}{self.GREEN}{record.msg}{self.RESET}"
         return super().format(record)


### PR DESCRIPTION
## Summary
- ensure `ColorizedFormatter` recognizes DEBUG log level

## Testing
- `python -m py_compile server.py`
- `python -m py_compile tests.py`
- `python tests.py --simple` *(fails: ANTHROPIC_API_KEY not set)*

------
https://chatgpt.com/codex/tasks/task_b_68410547681c8324bceb129fb7e92fef

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed log formatting issues to prevent errors and improve reliability when processing log messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->